### PR TITLE
sock 多次建联, 导致tcp连接占用涨满

### DIFF
--- a/lib/motan/endpoint/motan.lua
+++ b/lib/motan/endpoint/motan.lua
@@ -70,6 +70,8 @@ function _M.connect(self)
     local ok, err = sock:connect(self.url.host, self.url.port)
     if err ~= nil then
         ngx.log(ngx.ERR, "socket connection error")
+    else
+        return ok, err
     end
     local use_weibo_mesh = false
     if
@@ -95,7 +97,7 @@ function _M.connect(self)
             return nil, "motan endpoint failed connect to weibo mesh, and also couldn't get the snapshots."
         end
     end
-    return ok, err
+    return sock:connect(self.url.host, self.url.port)
 end
 
 function _M.call(self, req)

--- a/lib/motan/endpoint/motan.lua
+++ b/lib/motan/endpoint/motan.lua
@@ -95,7 +95,7 @@ function _M.connect(self)
             return nil, "motan endpoint failed connect to weibo mesh, and also couldn't get the snapshots."
         end
     end
-    return sock:connect(self.url.host, self.url.port)
+    return ok, err
 end
 
 function _M.call(self, req)

--- a/lib/motan/protocol/motan2/init.lua
+++ b/lib/motan/protocol/motan2/init.lua
@@ -205,7 +205,8 @@ function _M.make_motan_request(self, url, fucname, ...)
         M_p = url.path,
         M_m = fucname,
         M_g = url.group,
-        M_pp = url.protocol
+        M_pp = url.protocol,
+        M_s = url.params.application
     }
     local request_id = utils.generate_request_id()
     local service_name = url.path

--- a/lib/motan/utils.lua
+++ b/lib/motan/utils.lua
@@ -71,8 +71,13 @@ function _M.get_local_ip()
     return ffi.string(ip)
 end
 
+local next_index = 0
 function _M.generate_request_id()
-    return string.format("%14d%04d%d%d", ngx.now() * 10000, ngx.worker.pid(), ngx.worker.id(), math.random(1, 9))
+    next_index = next_index + 1
+    if next_index > 999 then
+        next_index = 0
+    end
+    return string.format("%d%13d%03d%03d", 1, ngx.now() * 1000, ngx.worker.id(), next_index)
 end
 
 function _M.build_service_key(group, version, protocol, path)


### PR DESCRIPTION
现象，大量的tcp连接占用。 导致抛出 not assign requested address
利用 motan debug 模式发现 motan endpoint failed connect to peer: socket connection error