### PR TITLE
ADD: fcall for full reponse

### DIFF
--- a/lib/motan/client/init.lua
+++ b/lib/motan/client/init.lua
@@ -23,6 +23,15 @@ end
 
 -- for calling with metadata
 function _M.call(self, fucname, metadata, ...)
+    local resp, err = self:fcall(fucname, metadata, ...)
+
+    if err ~= nil then
+        return nil, err
+    end
+    return resp.value
+end
+
+function _M.fcall(self, fucname, metadata, ...)
     local protocol = singletons.motan_ext:get_protocol(self.url.protocol)
     local req = protocol:make_motan_request(self.url, fucname, ...)
     if not utils.is_empty(metadata) then
@@ -31,10 +40,7 @@ function _M.call(self, fucname, metadata, ...)
         end
     end
     local resp = self.cluster:call(req)
-    if resp:get_exception() ~= nil then
-        return nil, resp:get_exception()
-    end
-    return resp.value
+    return resp, resp:get_exception()
 end
 
 -- for purge RPC call

--- a/lib/motan/core/response.lua
+++ b/lib/motan/core/response.lua
@@ -12,7 +12,8 @@ function _M.new(self, opts)
         value = opts.value or nil,
         exception = opts.exception or nil,
         process_time = opts.process_time or nil,
-        attachments = opts.attachments or {}
+        attachments = opts.attachments or {},
+        reused_times = opts.reused_times or nil
         -- RpcContext = opts.RpcContext or nil,
     }
     return setmetatable(response, mt)
@@ -55,5 +56,13 @@ end
 
 -- function _M.grocessDeserializable(self, toType)
 -- end
+
+function _M.get_reused_times(self)
+    return self.reused_times
+end
+
+function _M.set_reused_times(self, times)
+    self.reused_times = times
+end
 
 return _M

--- a/lib/motan/endpoint/motan.lua
+++ b/lib/motan/endpoint/motan.lua
@@ -69,7 +69,12 @@ function _M.connect(self)
     if not sock then
         return nil, "not initialized"
     end
-    local ok, err = sock:connect(self.url.host, self.url.port)
+    local ok, err
+    if self.url.unixSock ~= "" then
+        ok, err = sock:connect("unix:" .. self.url.unixSock)
+    else
+        ok, err = sock:connect(self.url.host, self.url.port)
+    end
     if err == nil then
         return ok, nil
     end
@@ -78,7 +83,7 @@ function _M.connect(self)
     if
         singletons.config.conf_set["WEIBO_MESH"] ~= nil and
             singletons.config.conf_set["WEIBO_MESH"] == table.concat({self.url.host, self.url.port}, ":")
-     then
+    then
         use_weibo_mesh = true
     end
     -- when connect fail to mesh, we need retry though snapshot nodes.

--- a/lib/motan/registry/direct.lua
+++ b/lib/motan/registry/direct.lua
@@ -15,7 +15,8 @@ local mt = {__index = _M}
 function _M:new(opts)
     local direct = {
         host = opts.host,
-        port = opts.port
+        port = opts.port,
+        unixSock = opts.unixSock
     }
     return setmetatable(direct, mt)
 end
@@ -44,6 +45,7 @@ function _M:discover(url)
         protocol = url.protocol,
         host = self.host,
         port = self.port,
+        unixSock = self.unixSock,
         path = url.path,
         group = url.group,
         params = url.params

--- a/lib/motan/url.lua
+++ b/lib/motan/url.lua
@@ -23,6 +23,7 @@ function _M.new(self, opts)
             host = opts.host or singletons.var.LOCAL_IP,
             port = opts.port or 0,
             path = opts.path or "",
+            unixSock = opts.unixSock or "",
             group = opts.group or "",
             params = opts.params or {}
         }
@@ -30,6 +31,7 @@ function _M.new(self, opts)
             "protocol",
             "host",
             "port",
+            "unixSock",
             "path",
             "group",
             "params"
@@ -46,12 +48,22 @@ function _M.new(self, opts)
 end
 
 function _M.get_addr(self)
+    local addr = {
+        self.host,
+        consts.COLON_SEPARATOR,
+        self.port
+    }
+
+    if self.unixSock ~= "" then
+        addr = {
+            self.unixSock
+        }
+    end
+
     local addr_info = {
         self.protocol,
         consts.PROTOCOL_SEPARATOR,
-        self.host,
-        consts.COLON_SEPARATOR,
-        self.port,
+        tab_concat(addr),
         consts.PATH_SEPARATOR
     }
     return tab_concat(addr_info)
@@ -63,10 +75,11 @@ function _M.copy(self)
     for k, v in pairs(self.params) do
         params[k] = v
     end
-    url.protocol, url.host, url.port, url.path, url.group, url.params =
+    url.protocol, url.host, url.port, url.unixSock, url.path, url.group, url.params =
         self.protocol,
         self.host,
         self.port,
+        self.unixSock,
         self.path,
         self.group,
         params
@@ -79,12 +92,22 @@ function _M.get_identity(self)
 end
 
 function _M.get_urlinfo(self, with_params_str)
+    local addr = {
+        self.host,
+        consts.COLON_SEPARATOR,
+        self.port
+    }
+
+    if self.unixSock ~= "" then
+        addr = {
+            self.unixSock
+        }
+    end
+
     local url_info = {
         self.protocol,
         consts.PROTOCOL_SEPARATOR,
-        self.host,
-        consts.COLON_SEPARATOR,
-        self.port,
+        tab_concat(addr),
         consts.PATH_SEPARATOR,
         self.path,
         consts.QMARK_SEPARATOR,


### PR DESCRIPTION
1. Extra info(backend is webserver return headers via mesh agent) maybe returned in attachment. Provide a func with full response returned
2. support connect with unix sock(motan-go support be connected via unix sock)
3. expose reused times for monitor usage